### PR TITLE
Added check for existing users with aliases

### DIFF
--- a/automation/Zhp.Office.AccountManagement/Zhp.Office.AccountManagement/Adapters/ActiveDirectory/AzureActiveDirectoryClient.cs
+++ b/automation/Zhp.Office.AccountManagement/Zhp.Office.AccountManagement/Adapters/ActiveDirectory/AzureActiveDirectoryClient.cs
@@ -34,7 +34,7 @@ namespace Zhp.Office.AccountManagement.Adapters.ActiveDirectory
 
             var existingUser = await client.Users.Request()
                 .Select(nameof(User.UserPrincipalName))
-                .Filter($"{nameof(User.UserPrincipalName)} eq '{email}'")
+                .Filter($"{nameof(User.UserPrincipalName)} eq '{email}' OR {nameof(User.ProxyAddresses)}/any(x:x eq 'smtp:{email}')")
                 .GetAsync(token);
 
             logger.LogDebug($"Found {existingUser.Count}.");


### PR DESCRIPTION
Dopisałem filtr, który powinien szukać również konta po aliasach.
Jest to problem, który teraz będzie się pojawiał jak tworzymy konta w @zhp.pl, a wszystkie konta mają aliasy do @zhp.pl.

Nie testowałem fixa w kodzie. Zrobiłem go na bazie Graph URL'a, który mi działa:
https://graph.microsoft.com/v1.0/users?$filter=userPrincipalName eq 'norbert.piatkowski@zhp.pl' OR proxyAddresses/any(x:x eq 'smtp:norbert.piatkowski@zhp.pl')

Rozwiązuje issue #11 